### PR TITLE
Force each regex to contain at least one '()' at the end of the pattern

### DIFF
--- a/src/Phroute/RouteCollector.php
+++ b/src/Phroute/RouteCollector.php
@@ -440,6 +440,10 @@ class RouteCollector implements RouteDataProviderInterface {
             $numVariables = count($firstRoute[2]);
             $numGroups = max($numGroups, $numVariables);
 
+            if ($numVariables === $numGroups) {
+                $numGroups++;
+            }
+            
             $regexes[] = $regex . str_repeat('()', $numGroups - $numVariables);
 
             foreach ($routes as $httpMethod => $route) {


### PR DESCRIPTION
Forcing the pattern to contain at least one '()' at the end of each regex seems to prevent similar routes from getting mixed up.